### PR TITLE
fix: resolve /checkout 404 — redirect to /myhealthcanvas + fix CTA links

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ import Terms from "./pages/Terms";
 import Impressum from "./pages/Impressum";
 import ThankYou from "./pages/ThankYou";
 import Start from "./pages/Start";
+import { Redirect } from "wouter";
 
 // Routes that should NOT show the global Header/Footer
 const noLayoutRoutes = ["/start"];
@@ -52,6 +53,8 @@ function Router() {
         <Route path="/privacy" component={Privacy} />
         <Route path="/terms" component={Terms} />
         <Route path="/impressum" component={Impressum} />
+        <Route path="/checkout">{() => <Redirect to="/myhealthcanvas" />}</Route>
+        <Route path="/checkout/:rest*">{() => <Redirect to="/myhealthcanvas" />}</Route>
         <Route path="/404" component={NotFound} />
         {/* Final fallback route */}
         <Route component={NotFound} />

--- a/client/src/pages/MyHealthCanvas.tsx
+++ b/client/src/pages/MyHealthCanvas.tsx
@@ -17,7 +17,7 @@ export default function MyHealthCanvas() {
   useEffect(() => {
     const handleScroll = () => {
       const scrollY = window.scrollY;
-      const buySection = document.getElementById('buy');
+      const buySection = document.getElementById('pricing');
       if (buySection) {
         const buyTop = buySection.getBoundingClientRect().top;
         // Show after 400px scroll, hide when pricing section is visible
@@ -200,7 +200,7 @@ export default function MyHealthCanvas() {
       </section>
 
       {/* PRICING SECTION - Both plans side by side, above fold on desktop */}
-      <section id="buy" className="py-16 px-6 md:px-12 lg:px-24" style={{ backgroundColor: '#FDFCF8' }}>
+      <section id="pricing" className="py-16 px-6 md:px-12 lg:px-24" style={{ backgroundColor: '#FDFCF8' }}>
         <div className="max-w-3xl mx-auto">
           
           <p className="text-center text-[18px] md:text-[20px] font-bold mb-10" style={{ background: 'linear-gradient(90deg, oklch(0.55 0.15 195), oklch(0.45 0.15 300))', WebkitBackgroundClip: 'text', WebkitTextFillColor: 'transparent' }}>50% of all proceeds are donated to cancer charities, to fund research.</p>
@@ -524,10 +524,10 @@ export default function MyHealthCanvas() {
               <p className="text-[12px] leading-tight" style={{ color: '#AACCCC' }}>Instant download · Yours forever</p>
             </div>
             <a
-              href="#buy"
+              href="#pricing"
               onClick={(e) => {
                 e.preventDefault();
-                document.getElementById('buy')?.scrollIntoView({ behavior: 'smooth' });
+                document.getElementById('pricing')?.scrollIntoView({ behavior: 'smooth' });
               }}
               className="text-white font-bold text-[14px] no-underline"
               style={{

--- a/client/src/pages/Welcome.tsx
+++ b/client/src/pages/Welcome.tsx
@@ -54,7 +54,7 @@ export default function Welcome() {
 
           {/* CTA Buttons - both above fold, stacked on mobile */}
           <div className="flex flex-col sm:flex-row items-center justify-center gap-4 pt-4">
-            <Link href="/checkout?plan=essential">
+            <Link href="/myhealthcanvas#pricing">
               <button
                 data-gtag-purchase
                 data-plan="essential"
@@ -68,7 +68,7 @@ export default function Welcome() {
                 Get my 1-page health plan — £19
               </button>
             </Link>
-            <Link href="/checkout?plan=complete">
+            <Link href="/myhealthcanvas#pricing">
               <button
                 data-gtag-purchase
                 data-plan="complete"


### PR DESCRIPTION
## Problem
19 visitors (3.92% of traffic) hitting Page Not Found — the homepage CTA buttons linked to /checkout, but no /checkout route existed.

## Fix (3 files)
- **Welcome.tsx** — CTA buttons now link to /myhealthcanvas#pricing
- **App.tsx** — /checkout and /checkout/* redirect to /myhealthcanvas (catches old bookmarks/Google cache)
- **MyHealthCanvas.tsx** — Pricing section id updated from buy to pricing for anchor consistency

## Impact
- Zero more 404s from purchase intent clicks
- Old /checkout URLs redirect properly
- Sticky mobile CTA bar still works