### PR TITLE
fix: mhc testimonials update + Bethesda Alterszentren spelling corrected sitewide

### DIFF
--- a/client/src/pages/Caregivers.tsx
+++ b/client/src/pages/Caregivers.tsx
@@ -192,7 +192,7 @@ export default function Caregivers() {
     <div className="min-h-screen" style={{ backgroundColor: "#FDFCF8" }}>
       <SEO
         title="Caregiver Support - MyHealthCanvas"
-        description="Supporting someone through illness? MyHealthCanvas helps caregivers stay organised, informed and in control. Piloted with families at Bethesda Alterzentren, Basel."
+        description="Supporting someone through illness? MyHealthCanvas helps caregivers stay organised, informed and in control. Piloted with families at Bethesda Alterszentren, Basel."
         keywords="cancer caregiver, caregiver support, caregiver questions, supporting cancer patient, caregiver toolkit, caregiver checklist, Age UK, caregiver health plan"
         canonicalPath="/caregivers"
       />
@@ -284,7 +284,7 @@ export default function Caregivers() {
           <div className="flex items-center justify-center gap-3 py-4 px-6 rounded-xl" style={{ backgroundColor: "rgba(25, 135, 140, 0.06)", border: "1px solid rgba(25, 135, 140, 0.12)" }}>
             <span className="text-[20px]">🏥</span>
             <p className="text-[15px] text-gray-700 font-medium">
-              Piloted with families at Bethesda Alterzentren, Basel, Switzerland
+              Piloted with families at Bethesda Alterszentren, Basel, Switzerland
             </p>
           </div>
 

--- a/client/src/pages/MyHealthCanvas.tsx
+++ b/client/src/pages/MyHealthCanvas.tsx
@@ -294,15 +294,15 @@ export default function MyHealthCanvas() {
           <div className="grid md:grid-cols-2 gap-6">
             <div className="p-6 bg-white rounded-xl border border-gray-100 space-y-3">
               <p className="text-[15px] text-gray-600 leading-[1.7] italic">
-                "[TESTIMONIAL] — I felt so much more in control walking into my appointment. Having everything written down meant I didn't forget a single question."
+                "I felt so much more in control walking into my appointment. Having everything written down meant I didn't forget a single question."
               </p>
-              <p className="text-[13px] text-gray-400 font-medium">— [Patient name, to be added]</p>
+              <p className="text-[13px] text-gray-400 font-medium">— Yolanda G, Switzerland · Patient</p>
             </div>
             <div className="p-6 bg-white rounded-xl border border-gray-100 space-y-3">
               <p className="text-[15px] text-gray-600 leading-[1.7] italic">
-                "[TESTIMONIAL] — As a caregiver, this gave me a way to stay organised and support my mum without feeling overwhelmed."
+                "As a caregiver, at first, I helped my mum fill it in — she was too overwhelmed by her diagnosis. But then after a while, she found keeping it updated on her phone helped her take back some control and feel organised."
               </p>
-              <p className="text-[13px] text-gray-400 font-medium">— [Caregiver name, to be added]</p>
+              <p className="text-[13px] text-gray-400 font-medium">— Armin G, Switzerland · Caregiver</p>
             </div>
           </div>
 
@@ -310,7 +310,7 @@ export default function MyHealthCanvas() {
           <div className="flex items-center justify-center gap-3 py-4">
             <span className="text-[20px]">🏥</span>
             <p className="text-[15px] text-gray-600 font-medium">
-              Used by families supported by Bethesda Alterzentren Basel
+              Used by families supported by Bethesda Alterszentren Basel
             </p>
           </div>
 

--- a/client/src/pages/Welcome.tsx
+++ b/client/src/pages/Welcome.tsx
@@ -94,7 +94,7 @@ export default function Welcome() {
             </div>
             <div className="flex items-center gap-3 px-4 py-3 rounded-lg" style={{ backgroundColor: '#FFFFFF', border: '1px solid #E1D7EB40' }}>
               <span className="text-[18px]">🏥</span>
-              <span className="text-[13px] text-gray-600 leading-tight text-left">Bethesda Alterzentren Basel — Home Companion Pilot Partner</span>
+              <span className="text-[13px] text-gray-600 leading-tight text-left">Bethesda Alterszentren Basel — Home Companion Pilot Partner</span>
             </div>
             <div className="flex items-center gap-3 px-4 py-3 rounded-lg" style={{ backgroundColor: '#FFFFFF', border: '1px solid #E1D7EB40' }}>
               <span className="text-[18px]">🔒</span>


### PR DESCRIPTION
## Changes

### 1. Testimonials updated (MyHealthCanvas.tsx)
- **Patient:** Yolanda G, Switzerland — "I felt so much more in control walking into my appointment. Having everything written down meant I didn't forget a single question."
- **Caregiver:** Armin G, Switzerland — Full caregiver-to-patient empowerment arc story

### 2. Spelling fix: Alterzentren → Alterszentren
Fixed across 3 files:
- Caregivers.tsx (2 occurrences)
- MyHealthCanvas.tsx (1 occurrence)
- Welcome.tsx (1 occurrence)

No instances of 'Bethesta' typo found in this repo (already correct).