### PR TITLE
feat: fire GA4 purchase event on MyHealthCanvas CTA buttons (MHC-002)

### DIFF
--- a/client/src/pages/MyHealthCanvas.tsx
+++ b/client/src/pages/MyHealthCanvas.tsx
@@ -232,7 +232,17 @@ export default function MyHealthCanvas() {
                     color: 'oklch(0.45 0.15 195)',
                     borderColor: 'oklch(0.55 0.15 195)',
                   }}
-                  onClick={() => document.getElementById('paypal-button-current')?.scrollIntoView({ behavior: 'smooth' })}
+                  onClick={() => {
+                    // Fire GA4 purchase event for Google Ads conversion tracking
+                    if (typeof window !== 'undefined' && (window as any).gtag) {
+                      (window as any).gtag('event', 'purchase', {
+                        currency: 'GBP',
+                        value: 19,
+                        items: [{ item_name: 'Essential Plan', price: 19, quantity: 1 }],
+                      });
+                    }
+                    document.getElementById('paypal-button-current')?.scrollIntoView({ behavior: 'smooth' });
+                  }}
                 >
                   Get this plan →
                 </button>
@@ -266,7 +276,17 @@ export default function MyHealthCanvas() {
                   style={{
                     background: 'linear-gradient(135deg, oklch(0.55 0.15 195), oklch(0.50 0.18 270))',
                   }}
-                  onClick={() => document.getElementById('paypal-button-complete')?.scrollIntoView({ behavior: 'smooth' })}
+                  onClick={() => {
+                    // Fire GA4 purchase event for Google Ads conversion tracking
+                    if (typeof window !== 'undefined' && (window as any).gtag) {
+                      (window as any).gtag('event', 'purchase', {
+                        currency: 'GBP',
+                        value: 27,
+                        items: [{ item_name: 'Complete Plan', price: 27, quantity: 1 }],
+                      });
+                    }
+                    document.getElementById('paypal-button-complete')?.scrollIntoView({ behavior: 'smooth' });
+                  }}
                 >
                   Get this plan →
                 </button>


### PR DESCRIPTION
## MHC-002: GA4 Purchase Event Tracking

### What
Adds `gtag('event', 'purchase', ...)` to both **"Get this plan →"** CTA buttons on the MyHealthCanvas product page.

### Why
The Google Ads conversion **"NEW MyHealthCanvas (web) purchase"** is active and correctly configured (Count: One, Value: Use different values, default £19), but shows **0 conversions** because the GA4 `purchase` event only fired on PayPal payment completion — and there have been no PayPal purchases yet.

This PR fires the `purchase` event on **CTA button click** (purchase intent), giving Google Ads the signal it needs to optimise campaigns immediately.

### Changes
- **Essential Plan button** (`£19`): fires `purchase` event with `{ currency: 'GBP', value: 19, items: [{ item_name: 'Essential Plan' }] }`
- **Complete Plan button** (`£27`): fires `purchase` event with `{ currency: 'GBP', value: 27, items: [{ item_name: 'Complete Plan' }] }`

### Double-counting prevention
The existing PayPal `onApprove` purchase events are preserved. Google Ads conversion is set to **Count: One**, so even if both the CTA click and PayPal completion fire for the same user session, only one conversion is recorded.

### Testing
1. Open `/myhealthcanvas` → click "Get this plan →" on either plan
2. Check browser console / GA4 DebugView for `purchase` event
3. Verify Google Ads conversion starts recording within 24-48 hours