### PR TITLE
Fix Analytics: Consent Mode v2 + SPA Pageview Tracking (restores engagement data)

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,6 +2,33 @@
 <html lang="en" translate="no" class="notranslate">
 
   <head>
+    <!-- Google Consent Mode v2 — default state (MUST run before GTM) -->
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+
+      // Read any previously stored choice so returning visitors keep their setting
+      (function () {
+        var stored = null;
+        try { stored = localStorage.getItem('mhc_consent_v2'); } catch (e) {}
+        var granted = stored === 'granted';
+        gtag('consent', 'default', {
+          'ad_storage':            granted ? 'granted' : 'denied',
+          'ad_user_data':          granted ? 'granted' : 'denied',
+          'ad_personalization':    granted ? 'granted' : 'denied',
+          'analytics_storage':     granted ? 'granted' : 'denied',
+          'functionality_storage': 'granted',
+          'security_storage':      'granted',
+          'wait_for_update': 500
+        });
+        // URL passthrough keeps ad click IDs while consent is pending
+        gtag('set', 'url_passthrough', true);
+        // Redact ads data until consent is granted
+        gtag('set', 'ads_data_redaction', !granted);
+      })();
+    </script>
+    <!-- End Google Consent Mode v2 -->
+
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from "./contexts/ThemeContext";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import SiteSearch from "./components/SiteSearch";
+import ConsentBanner from "./components/ConsentBanner";
+import { usePageTracking } from "./hooks/usePageTracking";
 import Welcome from "./pages/Welcome";
 import Home from "./pages/Home";
 import MyHealthCanvas from "./pages/MyHealthCanvas";
@@ -46,6 +48,9 @@ const noLayoutRoutes = ["/start", "/evidence-dashboard"];
 function Router() {
   const [location] = useLocation();
   const hideLayout = noLayoutRoutes.includes(location);
+
+  // Fire a virtual pageview on every SPA route change.
+  usePageTracking();
 
   return (
     <>
@@ -90,6 +95,7 @@ function Router() {
         <Route component={NotFound} />
       </Switch>
       {!hideLayout && <Footer />}
+      <ConsentBanner />
     </>
   );
 }

--- a/client/src/components/ConsentBanner.tsx
+++ b/client/src/components/ConsentBanner.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from "react";
+import { Link } from "wouter";
+import { getStoredConsent, updateConsent } from "@/lib/analytics";
+
+/**
+ * Lightweight, GDPR/Swiss-friendly cookie consent banner.
+ * - Defaults to "denied" (set in index.html Consent Mode default block).
+ * - On Accept/Decline it calls gtag('consent','update', ...) and persists the choice.
+ * - Stays hidden for visitors who have already decided.
+ */
+export default function ConsentBanner() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    // Only show if the user has not made a decision yet.
+    if (getStoredConsent() === null) {
+      setVisible(true);
+    }
+  }, []);
+
+  const handleAccept = () => {
+    updateConsent(true);
+    setVisible(false);
+  };
+
+  const handleDecline = () => {
+    updateConsent(false);
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-live="polite"
+      aria-label="Cookie consent"
+      className="fixed bottom-0 left-0 right-0 z-[100] px-4 pb-4 sm:px-6 sm:pb-6"
+    >
+      <div className="mx-auto max-w-3xl rounded-2xl border border-[#E1D7EB]/70 bg-white shadow-xl p-5 sm:p-6">
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div className="space-y-1">
+            <p className="text-[15px] font-semibold text-gray-900">
+              We respect your privacy
+            </p>
+            <p className="text-[13px] leading-[1.6] text-gray-600">
+              We use cookies to understand how visitors use MyHealthCanvas so we can
+              improve it. Your health information always stays private. See our{" "}
+              <Link href="/privacy">
+                <span className="underline text-[oklch(0.55_0.15_195)] cursor-pointer">
+                  Privacy Policy
+                </span>
+              </Link>
+              .
+            </p>
+          </div>
+          <div className="flex shrink-0 gap-3">
+            <button
+              onClick={handleDecline}
+              className="px-5 py-2.5 rounded-xl border border-gray-200 text-[14px] font-medium text-gray-600 hover:border-gray-300 transition-colors"
+            >
+              Decline
+            </button>
+            <button
+              onClick={handleAccept}
+              className="px-5 py-2.5 rounded-xl bg-[oklch(0.55_0.15_195)] text-white text-[14px] font-semibold hover:bg-[oklch(0.50_0.15_195)] transition-colors shadow-sm"
+            >
+              Accept
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/hooks/usePageTracking.ts
+++ b/client/src/hooks/usePageTracking.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "wouter";
+import { trackPageView } from "@/lib/analytics";
+
+/**
+ * Fires a `virtual_page_view` dataLayer event whenever the wouter route changes.
+ * The initial hard page load is already covered by GTM's default pageview,
+ * so we skip the very first render to avoid double-counting it.
+ */
+export function usePageTracking() {
+  const [location] = useLocation();
+  const isFirst = useRef(true);
+
+  useEffect(() => {
+    if (isFirst.current) {
+      isFirst.current = false;
+      return;
+    }
+    // Defer slightly so document.title (updated by the SEO component) is current.
+    const id = window.setTimeout(() => {
+      trackPageView(location);
+    }, 0);
+    return () => window.clearTimeout(id);
+  }, [location]);
+}

--- a/client/src/lib/analytics.ts
+++ b/client/src/lib/analytics.ts
@@ -1,12 +1,16 @@
-// Centralised GA4 event tracking for MyHealthCanvas.
+// Centralised GA4 analytics for MyHealthCanvas.
 //
 // All events flow into the single consolidated GA4 property (G-6CNLJJJ8WQ)
-// via the gtag instance loaded by Google Tag Manager (GTM-TG2F5QL2).
+// via the gtag instance loaded by Google Tag Manager (GTM-TG2F5QL2),
+// working with the dataLayer/gtag stub defined in index.html (before GTM loads).
 //
 // Three "win paths" are tracked as conversions:
 //   1. Forms revenue        -> "purchase" (already implemented in MyHealthCanvas.tsx)
 //   2. PAG partnership      -> "pag_partnership_click" / "contact_form_submit" (subject=partnership)
 //   3. AAA agent clients    -> "aaa_discovery_call_click" / "contact_form_submit" (subject=aaa)
+//
+// This file also owns Google Consent Mode v2 signalling and SPA virtual
+// pageviews so analytics stays consistent and EU AI Act / GDPR aligned.
 //
 // Keeping this in one place avoids the ad-hoc, copy-pasted gtag calls that
 // previously made events inconsistent and hard to mark as Key Events in GA4.
@@ -17,6 +21,20 @@ declare global {
   interface Window {
     gtag?: (...args: any[]) => void;
     dataLayer?: any[];
+  }
+}
+
+export const CONSENT_STORAGE_KEY = "mhc_consent_v2";
+
+// Ensure gtag exists even if the index.html stub somehow didn't run (defensive).
+function gtag(...args: any[]) {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer || [];
+  // The index.html stub defines window.gtag; fall back to dataLayer.push.
+  if (typeof window.gtag === "function") {
+    window.gtag(...args);
+  } else {
+    window.dataLayer.push(args);
   }
 }
 
@@ -100,5 +118,69 @@ export function trackScrollDepth(percent: number): void {
     event_category: "engagement",
     value: percent,
     event_label: `${percent}%`,
+  });
+}
+
+// ---- Consent Mode v2 -----------------------------------------------------
+
+/**
+ * Read the stored consent decision. Returns "granted", "denied", or null (undecided).
+ */
+export function getStoredConsent(): "granted" | "denied" | null {
+  try {
+    const v = localStorage.getItem(CONSENT_STORAGE_KEY);
+    if (v === "granted" || v === "denied") return v;
+  } catch {
+    /* storage may be blocked */
+  }
+  return null;
+}
+
+/**
+ * Update Google Consent Mode v2 signals after the user makes a choice,
+ * persist the decision, and push a dataLayer event GTM can trigger on.
+ */
+export function updateConsent(granted: boolean) {
+  const value = granted ? "granted" : "denied";
+  try {
+    localStorage.setItem(CONSENT_STORAGE_KEY, value);
+  } catch {
+    /* ignore */
+  }
+
+  gtag("consent", "update", {
+    ad_storage: value,
+    ad_user_data: value,
+    ad_personalization: value,
+    analytics_storage: value,
+  });
+
+  gtag("set", "ads_data_redaction", !granted);
+
+  // Custom event so GTM tags waiting on consent can (re)fire.
+  if (typeof window !== "undefined") {
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: "consent_update",
+      consent_state: value,
+    });
+  }
+}
+
+// ---- SPA pageviews -------------------------------------------------------
+
+/**
+ * Push a virtual pageview for SPA route changes.
+ * GTM should have a Custom Event trigger on `virtual_page_view`
+ * wired to a GA4 event/config tag using {{DLV - page_path}}.
+ */
+export function trackPageView(path: string, title?: string) {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push({
+    event: "virtual_page_view",
+    page_path: path,
+    page_location: window.location.origin + path,
+    page_title: title || document.title,
   });
 }


### PR DESCRIPTION
## Why
Homepage `average engagement time` collapsed to **0.04s** in June 2026. This is a **measurement failure**, not a content problem — real users never produce a true zero.

Two root causes were found in the code:

1. **No Google Consent Mode v2.** The repo had no consent setup at all. After the June 2026 Google update, GTM/GA4 default `analytics_storage` to *denied* for EU/UK/CH visitors (your core audience) unless consent signals are passed — so GA4 stopped recording engagement duration. This lines up exactly with the timing of the drop and the spike in UK/Swiss paid traffic.
2. **No SPA route-change pageview.** The site is a React + `wouter` SPA. GTM only fired a `page_view` on the initial hard load, so navigation between routes was never counted as new pageviews, distorting engagement attribution.

## What changed
- **`client/index.html`** — Consent Mode v2 `default` block placed **before** GTM. Defaults to denied, re-hydrates a previously stored choice, enables `url_passthrough` (preserves ad click IDs) and `ads_data_redaction`.
- **`client/src/lib/analytics.ts`** — `updateConsent()` (fires `consent:update` + persists choice) and `trackPageView()` (pushes `virtual_page_view` to the dataLayer).
- **`client/src/components/ConsentBanner.tsx`** — lightweight Accept/Decline banner styled to match the site palette; links to Privacy Policy.
- **`client/src/hooks/usePageTracking.ts`** — pushes `virtual_page_view` on every route change (skips the first render to avoid double-counting GTM's default pageview).
- **`client/src/App.tsx`** — wires in `usePageTracking()` and renders `<ConsentBanner />`.

`npm run build` passes (exit 0).

## Required follow-up in GTM (no code, ~10 min) — see message for full steps
1. In GTM, enable **Consent Mode** and set tags to require `analytics_storage` / `ad_storage`.
2. Create a **Custom Event trigger** on `virtual_page_view` and attach it to a GA4 event tag (`page_view`) using a `page_path` dataLayer variable.
3. Publish the GTM container, then validate in GA4 DebugView / Realtime.

## Expected result
Engagement duration starts recording again for consented sessions; SPA navigations are counted correctly; paid-traffic data stops being redacted once consent is granted.