### PR TITLE
Add subtle 'Coming Soon: Patient Memory' teaser to MyHealthCanvas (vision, not delivered)

### DIFF
--- a/client/src/pages/MyHealthCanvas.tsx
+++ b/client/src/pages/MyHealthCanvas.tsx
@@ -591,6 +591,20 @@ export default function MyHealthCanvas() {
         </div>
       </section>
 
+      {/* COMING SOON: PATIENT MEMORY - emerging direction teaser (vision, not a delivered capability) */}
+      <section className="py-14 px-6 md:px-12 lg:px-24" style={{ backgroundColor: "#f9f9f7" }}>
+        <div className="max-w-2xl mx-auto">
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm p-8 md:p-10 text-center space-y-4">
+            <span className="inline-block text-[12px] font-bold tracking-[0.08em] uppercase text-[#369994] bg-[oklch(0.95_0.03_195)] rounded-full px-4 py-1.5">Coming soon</span>
+            <h2 className="text-[22px] md:text-[28px] font-bold text-gray-800 leading-[1.25]">We're building Patient Memory</h2>
+            <p className="text-[16px] text-gray-600 leading-[1.7]">
+              MyHealthCanvas is the first practical step. Today it helps you prepare, remember and capture what matters for each appointment. Next, we're working towards helping you <strong>carry that information forward</strong> &mdash; across appointments, clinicians and care settings &mdash; so your next appointment can start where the last one finished.
+            </p>
+            <p className="text-[13px] font-semibold text-[#369994]">Our vision for continuity of care &mdash; an emerging capability we're developing, not yet available.</p>
+          </div>
+        </div>
+      </section>
+
       <section className="py-14 px-6 md:px-12 lg:px-24" style={{ backgroundColor: "#FDFCF8" }}>
         <div className="max-w-2xl mx-auto text-center space-y-6">
           <h2 className="text-[22px] md:text-[26px] font-bold text-gray-800">How we protect you</h2>

--- a/client/src/pages/Welcome.tsx
+++ b/client/src/pages/Welcome.tsx
@@ -275,6 +275,25 @@ export default function Welcome() {
         </div>
       </section>
 
+      {/* COMING SOON: PATIENT MEMORY - emerging direction teaser (vision, not a delivered capability) */}
+      <section className="py-16 px-6 md:px-12 lg:px-24" style={{ backgroundColor: '#FDFCF8' }}>
+        <div className="max-w-3xl mx-auto">
+          <div className="rounded-2xl border border-gray-200 bg-white shadow-sm p-8 md:p-10 text-center space-y-5">
+            <span className="inline-block text-[12px] font-bold tracking-[0.08em] uppercase text-[#369994] bg-[oklch(0.95_0.03_195)] rounded-full px-4 py-1.5">Coming soon</span>
+            <h2 className="text-[24px] md:text-[30px] font-bold text-gray-900 leading-[1.25]">
+              We're building Patient Memory
+            </h2>
+            <p className="text-[16px] md:text-[17px] text-gray-600 leading-[1.7]">
+              Today, MyHealthCanvas helps you prepare, remember and capture what matters for each appointment. Next, we're working towards helping you <strong>carry that information forward</strong> — across appointments, clinicians and care settings — so your next appointment can start where the last one finished.
+            </p>
+            <p className="text-[15px] text-gray-500 leading-[1.7] italic">
+              Our vision for continuity of care: you don't have to remember everything, you won't lose what's important, and your family can help &mdash; all in one place you control.
+            </p>
+            <p className="text-[13px] font-semibold text-[#369994]">An emerging capability we're developing &mdash; not yet available.</p>
+          </div>
+        </div>
+      </section>
+
       {/* IS MYHEALTHCANVAS RIGHT FOR ME? */}
       <section className="py-14 px-6 md:px-12 lg:px-24" style={{ backgroundColor: '#FDFCF8' }}>
         <div className="max-w-3xl mx-auto space-y-8">


### PR DESCRIPTION
## Add subtle "Coming Soon: Patient Memory" teaser to MyHealthCanvas

Aligns MyHealthCanvas with the Home Companion **Patient Memory** narrative — but deliberately **lighter**. Per the brief, this does **not** reposition MyHealthCanvas as if Patient Memory / Continuity of Care already exist. It presents MyHealthCanvas as **the place where Patient Memory begins** — "the first practical step", with Home Companion holding the longer-term vision.

> **Home Companion** — "the future of Patient Memory" → **MyHealthCanvas** — "the first practical step towards Patient Memory."

### What changed (additive only — +33 lines, 2 files)
- **Homepage (`Welcome.tsx`):** a "Coming Soon: Patient Memory" card inserted after the *Before / During / After / Between Appointments* ("How patients actually use MyHealthCanvas") section.
- **Product page (`MyHealthCanvas.tsx`):** a condensed matching teaser inserted after the free-checklist CTA, before the "How we protect you" privacy section.

Both cards reuse the existing white-card + brand-teal styling (brand hex `#369994`, existing `oklch(0.95 0.03 195)` token) so they read as native, not bolted-on.

### Framing discipline (exactly per the brief)
- **Today's value stays primary** — prepare, remember what matters, organise, capture, share with family. Hero, SEO, and CTAs untouched.
- **Patient Memory + Continuity of Care = vision, not delivered.** Wording: *"we're building"*, *"working towards"*, *"our vision for continuity of care"*, and an explicit *"an emerging capability we're developing — not yet available."*
- **Emotional, patient/caregiver-first** — *"you don't have to remember everything, you won't lose what's important, and your family can help"*, *"your next appointment can start where the last one finished."*
- **No Safety OS / Human-Agent Governance / infrastructure language** anywhere on these patient pages (verified by grep — zero matches). Patients experience the benefit, not the infrastructure.

### Deliberately preserved
Oncology hero headline + SEO keywords ("questions to ask your oncologist"), all conversion CTAs (Questions for Your Oncologist, Get free checklist), GA tracking, brand palette/tokens, and all existing copy. **Nothing removed or reworded** — purely additive.

### Validation
- `tsc --noEmit` (pnpm check): **passes, no errors**
- `pnpm build`: **succeeds**
- Rendered locally and visually verified the teaser displays correctly in context on the homepage.

### Scope
Only `myhealthcanvas-website` (homepage + product page). `homecompanion` product repo and the PatientCentricCare.AI / Home Companion pages untouched.
