### PR TITLE
fix: reliable GA4 purchase event on PayPal checkout

### DIFF
--- a/client/src/lib/analytics.ts
+++ b/client/src/lib/analytics.ts
@@ -1,8 +1,10 @@
 // Centralised GA4 analytics for MyHealthCanvas.
 //
-// All events flow into the single consolidated GA4 property (G-6CNLJJJ8WQ)
+// All events flow into the "NEW MyHealthCanvas" GA4 web stream (G-YYX090N0HV)
 // via the gtag instance loaded by Google Tag Manager (GTM-TG2F5QL2),
 // working with the dataLayer/gtag stub defined in index.html (before GTM loads).
+// NOTE: the GA4 Measurement ID is configured inside the GTM container's Google
+// Tag, NOT hardcoded here. This comment is documentation only.
 //
 // Three "win paths" are tracked as conversions:
 //   1. Forms revenue        -> "purchase" (already implemented in MyHealthCanvas.tsx)
@@ -88,6 +90,91 @@ export function trackContactFormSubmit(subject: string): void {
     lead_type: contactSubjectToLeadType(subject),
     event_label: subject || "unspecified",
   });
+}
+
+// ---- Purchase (forms revenue) -------------------------------------------
+
+/**
+ * Fires the GA4 `purchase` event reliably, then runs `onComplete` (typically a
+ * redirect to the thank-you page).
+ *
+ * Why this exists: the previous code fired `gtag("event", "purchase", ...)` and
+ * then immediately set `window.location.href`. gtag sends its hit asynchronously
+ * (a beacon), so navigating away in the same tick frequently cancelled the
+ * request before it left the browser. The result: real PayPal sales captured
+ * fine, but the `purchase` event never reached GA4 ("No stream data detected").
+ *
+ * Here we pass `event_callback` so the redirect only runs once the beacon has
+ * been dispatched, with a `setTimeout` safety net so checkout NEVER hangs if
+ * GA is blocked, slow, or consent-denied. We also guard against double-firing.
+ */
+export interface PurchaseDetails {
+  transactionId?: string;
+  value: number;
+  currency?: string;
+  itemName: string;
+}
+
+let purchaseFired = false;
+
+export function trackPurchase(details: PurchaseDetails, onComplete?: () => void): void {
+  const finish = (() => {
+    let done = false;
+    return () => {
+      if (done) return;
+      done = true;
+      if (onComplete) onComplete();
+    };
+  })();
+
+  // Always complete (redirect) even if analytics is unavailable or slow.
+  const safetyTimer = setTimeout(finish, 1200);
+
+  if (typeof window === "undefined") {
+    clearTimeout(safetyTimer);
+    finish();
+    return;
+  }
+
+  // Guard: never log the same purchase twice in one page session.
+  if (purchaseFired) {
+    clearTimeout(safetyTimer);
+    finish();
+    return;
+  }
+  purchaseFired = true;
+
+  const payload: Record<string, unknown> = {
+    value: details.value,
+    currency: details.currency || "GBP",
+    items: [{ item_name: details.itemName, price: details.value, quantity: 1 }],
+    page_path: window.location.pathname,
+    event_callback: () => {
+      clearTimeout(safetyTimer);
+      finish();
+    },
+  };
+  if (details.transactionId) payload.transaction_id = details.transactionId;
+
+  try {
+    if (typeof window.gtag === "function") {
+      window.gtag("event", "purchase", payload);
+    } else if (Array.isArray(window.dataLayer)) {
+      // No gtag yet: still record for GTM, then complete immediately.
+      window.dataLayer.push({ event: "purchase", ...payload });
+      clearTimeout(safetyTimer);
+      finish();
+    } else {
+      clearTimeout(safetyTimer);
+      finish();
+    }
+  } catch (err) {
+    // Never let analytics break the checkout flow.
+    // eslint-disable-next-line no-console
+    console.warn("trackPurchase failed:", err);
+    clearTimeout(safetyTimer);
+    finish();
+  }
 }
 
 function contactSubjectToLeadType(subject: string): string {

--- a/client/src/pages/MyHealthCanvas.tsx
+++ b/client/src/pages/MyHealthCanvas.tsx
@@ -4,6 +4,7 @@ import { Link } from "wouter";
 import SEO from "@/components/SEO";
 import PatientStories from "@/components/PatientStories";
 import CaregiverCompanion from "@/components/CaregiverCompanion";
+import { trackPurchase } from "@/lib/analytics";
 
 declare global {
   interface Window {
@@ -62,15 +63,19 @@ export default function MyHealthCanvas() {
           },
           onApprove: function (_data: any, actions: any) {
             return actions.order.capture().then(function () {
-              if (typeof window !== "undefined" && (window as any).gtag) {
-                (window as any).gtag("event", "purchase", {
-                  transaction_id: _data.orderID,
+              // Fire the purchase event, then redirect only once GA has sent the
+              // beacon (with a timeout fallback so checkout never hangs).
+              trackPurchase(
+                {
+                  transactionId: _data.orderID,
                   value: 19.0,
                   currency: "GBP",
-                  items: [{ item_name: "MyHealthCanvas Essential Appointment Companion", price: 19.0, quantity: 1 }],
-                });
-              }
-              window.location.href = `/myhealthcanvas/thank-you?product=current&order_id=${_data.orderID}`;
+                  itemName: "MyHealthCanvas Essential Appointment Companion",
+                },
+                () => {
+                  window.location.href = `/myhealthcanvas/thank-you?product=current&order_id=${_data.orderID}`;
+                },
+              );
             });
           },
           onError: function (err: any) {
@@ -92,15 +97,17 @@ export default function MyHealthCanvas() {
           },
           onApprove: function (_data: any, actions: any) {
             return actions.order.capture().then(function () {
-              if (typeof window !== "undefined" && (window as any).gtag) {
-                (window as any).gtag("event", "purchase", {
-                  transaction_id: _data.orderID,
+              trackPurchase(
+                {
+                  transactionId: _data.orderID,
                   value: 27.0,
                   currency: "GBP",
-                  items: [{ item_name: "MyHealthCanvas Complete Care & Future Planning Companion", price: 27.0, quantity: 1 }],
-                });
-              }
-              window.location.href = `/myhealthcanvas/thank-you?product=complete&order_id=${_data.orderID}`;
+                  itemName: "MyHealthCanvas Complete Care & Future Planning Companion",
+                },
+                () => {
+                  window.location.href = `/myhealthcanvas/thank-you?product=complete&order_id=${_data.orderID}`;
+                },
+              );
             });
           },
           onError: function (err: any) {
@@ -456,13 +463,8 @@ export default function MyHealthCanvas() {
                   className="w-full py-3 rounded-lg text-[16px] font-semibold transition-all duration-300 hover:shadow-lg border-2 cursor-pointer"
                   style={{ backgroundColor: "#FFFFFF", color: "oklch(0.45 0.15 195)", borderColor: "oklch(0.55 0.15 195)" }}
                   onClick={() => {
-                    if (typeof window !== "undefined" && (window as any).gtag) {
-                      (window as any).gtag("event", "purchase", {
-                        currency: "GBP",
-                        value: 19,
-                        items: [{ item_name: "Essential Appointment Companion", price: 19, quantity: 1 }],
-                      });
-                    }
+                    // Intent signal only — NOT a purchase. The real `purchase`
+                    // event fires on PayPal onApprove (payment captured).
                     document.getElementById("paypal-button-current")?.scrollIntoView({ behavior: "smooth" });
                   }}
                 >
@@ -498,13 +500,8 @@ export default function MyHealthCanvas() {
                   className="w-full py-3 rounded-lg text-[16px] font-semibold text-white transition-all duration-300 hover:shadow-lg cursor-pointer"
                   style={{ background: "linear-gradient(135deg, oklch(0.55 0.15 195), oklch(0.50 0.18 270))" }}
                   onClick={() => {
-                    if (typeof window !== "undefined" && (window as any).gtag) {
-                      (window as any).gtag("event", "purchase", {
-                        currency: "GBP",
-                        value: 27,
-                        items: [{ item_name: "Complete Care & Future Planning Companion", price: 27, quantity: 1 }],
-                      });
-                    }
+                    // Intent signal only — NOT a purchase. The real `purchase`
+                    // event fires on PayPal onApprove (payment captured).
                     document.getElementById("paypal-button-complete")?.scrollIntoView({ behavior: "smooth" });
                   }}
                 >

--- a/client/src/pages/Start.tsx
+++ b/client/src/pages/Start.tsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardFooter, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { useEffect } from "react";
 import SEO from "@/components/SEO";
+import { trackPurchase } from "@/lib/analytics";
 
 declare global {
   interface Window {
@@ -36,22 +37,18 @@ export default function Start() {
               });
             },
             onApprove: function (_data: any, actions: any) {
-              return actions.order.capture().then(function (details: any) {
-                if (typeof window !== "undefined" && (window as any).gtag) {
-                  (window as any).gtag("event", "purchase", {
-                    transaction_id: _data.orderID,
+              return actions.order.capture().then(function () {
+                trackPurchase(
+                  {
+                    transactionId: _data.orderID,
                     value: 19.0,
                     currency: "GBP",
-                    items: [
-                      {
-                        item_name: "MyHealthCanvas Current Plan",
-                        price: 19.0,
-                        quantity: 1,
-                      },
-                    ],
-                  });
-                }
-                window.location.href = `/myhealthcanvas/thank-you?product=current&order_id=${_data.orderID}`;
+                    itemName: "MyHealthCanvas Current Plan",
+                  },
+                  () => {
+                    window.location.href = `/myhealthcanvas/thank-you?product=current&order_id=${_data.orderID}`;
+                  },
+                );
               });
             },
             onError: function (err: any) {
@@ -80,22 +77,18 @@ export default function Start() {
               });
             },
             onApprove: function (_data: any, actions: any) {
-              return actions.order.capture().then(function (details: any) {
-                if (typeof window !== "undefined" && (window as any).gtag) {
-                  (window as any).gtag("event", "purchase", {
-                    transaction_id: _data.orderID,
+              return actions.order.capture().then(function () {
+                trackPurchase(
+                  {
+                    transactionId: _data.orderID,
                     value: 27.0,
                     currency: "GBP",
-                    items: [
-                      {
-                        item_name: "MyHealthCanvas Complete Plan",
-                        price: 27.0,
-                        quantity: 1,
-                      },
-                    ],
-                  });
-                }
-                window.location.href = `/myhealthcanvas/thank-you?product=complete&order_id=${_data.orderID}`;
+                    itemName: "MyHealthCanvas Complete Plan",
+                  },
+                  () => {
+                    window.location.href = `/myhealthcanvas/thank-you?product=complete&order_id=${_data.orderID}`;
+                  },
+                );
               });
             },
             onError: function (err: any) {


### PR DESCRIPTION
## Problem
GA4 (NEW MyHealthCanvas, `G-YYX090N0HV`) shows **"No stream data detected"** for the `purchase` event, even though PayPal checkout completes and the thank-you page loads. Real sales are not being recorded as conversions.

## Root cause
The PayPal `onApprove` handlers fired `gtag("event", "purchase", ...)` and then **immediately** set `window.location.href`. gtag sends its hit asynchronously, so navigating away in the same tick cancelled the beacon before it left the browser — a classic race condition. Page views tracked fine (they re-fire on the new page); the purchase event did not.

A second, subtler bug: the two pricing **scroll buttons** fired a `purchase` event on click (before any payment, with no `transaction_id`). Once the beacon issue was fixed, these would have **inflated revenue with phantom conversions**.

## Fix
- New `trackPurchase()` helper in `client/src/lib/analytics.ts`:
  - Uses gtag **`event_callback`** so the redirect runs only after the beacon is dispatched.
  - **1200ms `setTimeout` fallback** so checkout never hangs if GA is blocked / slow / consent-denied.
  - Guards against double-firing within a page session.
- Wired all **4** PayPal `onApprove` handlers: `MyHealthCanvas.tsx` (×2) and `Start.tsx` (×2).
- Removed the **2 bogus pre-payment** `purchase` events on the scroll buttons (now intent-only scroll, no event).
- Fixed a stale Measurement ID comment (`G-6CNLJJJ8WQ` → `G-YYX090N0HV`).

## Scope / safety
- **No** UX, copy, design, or pricing changes. PayPal flow, £19/£27 plans, and the 50%-to-charity messaging are untouched.
- `pnpm build` passes (1718 modules). `tsc --noEmit` passes.

## How to verify after deploy
1. Open myhealthcanvas.com in Incognito, accept the consent banner.
2. Complete a test purchase.
3. GA4 → Admin → **DebugView** (or Realtime → Event count) → confirm `purchase` fires with `value` + `transaction_id`.
4. Then mark `purchase` as a **Key event** and import into Google Ads.